### PR TITLE
restructure content team site and private group

### DIFF
--- a/05a-Projects.Rmd
+++ b/05a-Projects.Rmd
@@ -556,14 +556,14 @@ If your dashboard was created in Power BI and you want to directly publish your 
 
 ### Team Site (TheHub)
 
-#### Update Team Site Annual Evaluation Plans
+The R&A Team Site Documents folder contains files we upload to the Team Site.
 
-The Team Site Documents folder holds files we upload to the Team Site.
+The [Team Site (TheHub)][Team Site (TheHub)] Documents folder is not to be confused with the R&A Private Group Documents folder. The [R&A Private Group][R&A Private Group] Documents folder contains shared folders R&A team members use for collaborative work and storage.
 
-For annual evaluation plans published to the [Team Site (TheHub)][Team Site (TheHub)], only the publication files are stored in the Team Site Documents folder > Evaluation > Evaluation Plans > FY 20## for organization and consistency purposes. 
+#### Published Evaluation Plans
 
-On an annual basis, save a copy of the final evaluation plan to the Team Site Documents folder and select for upload to the R&A Team Site.
+Evaluation plans are published annually to the [Team Site (TheHub)][Team Site (TheHub)]. Published evaluation plan files are stored in the Team Site Documents folder > Evaluation > Evaluation Plans > FY 20## for accessibility, consistency, and organization purposes.
 
-The [Team Site (TheHub)][Team Site (TheHub)] and 
-Team Site Documents folder are not to be confused with the R&A Private Group Documents folder. The [R&A Private Group][R&A Private Group] Documents folder contains shared folders R&A team members use for collaborative work and storage.
+On an annual basis, save copy of each final, approved, ready-for-publication evaluation plan to the appropriate Team Site Documents folder. Select files for upload to the R&A Team Site.
+
 


### PR DESCRIPTION
re-organized and cleaned up sentence structure for publishing content to team site example for evaluation plans; added sentences about the Team Site vs Private Group to under the Team Site (TheHub) section.